### PR TITLE
chore: cache time offsetMinutes

### DIFF
--- a/src/Services/FresnsImageXService.php
+++ b/src/Services/FresnsImageXService.php
@@ -315,7 +315,7 @@ class FresnsImageXService
                 }
             }
 
-            $cacheTime = CacheHelper::fresnsCacheTimeByFileType($file->type);
+            $cacheTime = CacheHelper::fresnsCacheTimeByFileType($file->type, null, 2);
             CacheHelper::put($fileInfo, $cacheKey, Constants::$cacheTags, 1, $cacheTime);
 
             $data = $fileInfo;


### PR DESCRIPTION
`CacheHelper::fresnsCacheTimeByFileType($fileType, $specificMinutes, $offsetMinutes)`

主程序获取缓存时间封装功能，增加了一个 `offsetMinutes` 参数，可以偏移时间，避免缓存不同时导致文件 URL 裂了。

比如用户资料的缓存是防盗链减 1 分钟，用户头像图片的防盗链也减 1 分钟，如果两边误差个几毫秒，可能就导致新的用户资料生成时，拿的是旧的头像图片缓存，旧头像缓存里的链接马上也失效了，就会导致头像裂了。

所以现在主程序封装的功能，允许自定义时间偏移，主程序默认是 1 分钟，文件插件可以定义偏移 2 分钟，提前结束缓存，保证下次使用文件时，拿到的是新一轮新缓存。